### PR TITLE
Make image tag available also as imapfilter version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
+            type=semver,pattern={{version}}
             type=match,pattern=v(.*),group=1
 
       - name: Build and push Docker image


### PR DESCRIPTION
Allowing users to pull based only on imapfilter version regardless of the build number.