### PR TITLE
Workaround behavior of metadata-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
             ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
-            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=match,pattern=v(.*),group=1
 
       - name: Build and push Docker image


### PR DESCRIPTION
Apparently the "version" semver pattern in this action pulls in build/pre-release part as well. Trying to see if this works preserving the original imapfilter version.