### PR TITLE
pinning alpine at version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.23.0
 
 ARG IMAPFILTER_CONFIG=/config
 ARG IMAPFILTER_LOGS=/logs
@@ -17,7 +17,7 @@ RUN set -xe \
 	&& apk update \
 	&& apk upgrade \
 	&& apk add --no-cache \
-		libcrypto1.1 libssl1.1 moreutils bash wget curl \
+		libcrypto3 libssl3 moreutils bash wget curl \
 	&& apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
 		imapfilter \
 	&& apk del --progress --purge \


### PR DESCRIPTION
updating the libs to current versions to fix current CVEs in the image
I would also reccomend to implement a renovate job to automaticly update the alpine base image 
as well as an auto release pipeline to keep the image from going stale


The following CVEs were found in the current version of the Image:
# 1. Overview

## 1.1 Product Information

Container image ghcr.io/sandipb/imapfilter@sha256:701cc48f63b8334003377d36bcc7630bd418161222c3004b5dbc81bbe6bf612a is built on the alpine 3.16.0 operating system, designed for the amd64 architecture, and has identified potential security issues during 17 Dec 25 16:49 CET security scans.

| Product Type | Container image |
|--- | --- |
| Product Name | ghcr.io/sandipb/imapfilter@sha256:701cc48f63b8334003377d36bcc7630bd418161222c3004b5dbc81bbe6bf612a |
| Creation date | 13 Jul 22 12:22 UTC |
| Architecture | amd64 |
| Operating System | alpine 3.16.0 |
| Mirror image ID | sha256:fe654f64002f98cda1756f7ffda0981c4839fdcc73ed4e9783fd0998a3f862bb |
| Scan time | 17 Dec 25 16:49 CET |

## 1.2 Mirror Configuration

The mirror creation history is shown below. Please manually check for any suspicious execution commands, such as downloading malicious files.

| Creation date | History |
|--- | --- |
| 2022-05-23 19:19:30 | /bin/sh -c #(nop) ADD file:8e81116368669ed3dd361bc898d61bff249f524139a239fdaf3ec46869a39921 in /  |
| 2022-05-23 19:19:31 | /bin/sh -c #(nop)  CMD ["/bin/sh"] |
| 2022-07-13 12:22:48 | ARG IMAPFILTER_CONFIG=/config |
| 2022-07-13 12:22:48 | ARG IMAPFILTER_LOGS=/logs |
| 2022-07-13 12:22:48 | VOLUME [/config] |
| 2022-07-13 12:22:48 | VOLUME [/logs] |
| 2022-07-13 12:22:48 | ENV HOME=/config |
| 2022-07-13 12:22:48 | WORKDIR /config |
| 2022-07-13 12:22:48 | RUN |2 IMAPFILTER_CONFIG=/config IMAPFILTER_LOGS=/logs /bin/sh -c set -xe 	&& addgroup --gid 2000 app 	&& adduser --uid 2000 --disabled-password --no-create-home --ingroup app app # buildkit |
| 2022-07-13 12:22:53 | RUN |2 IMAPFILTER_CONFIG=/config IMAPFILTER_LOGS=/logs /bin/sh -c set -xe 	&& apk update 	&& apk upgrade 	&& apk add --no-cache 		libcrypto1.1 libssl1.1 moreutils bash wget curl 	&& apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ 		imapfilter 	&& apk del --progress --purge 	&& rm -rf /var/cache/apk/* # buildkit |
| 2022-07-13 12:22:53 | USER app |
| 2022-07-13 12:22:53 | COPY ./entrypoint.sh / # buildkit |
| 2022-07-13 12:22:53 | ENTRYPOINT ["/entrypoint.sh"] |

Configuration details for the mirror are listed below. Please manually inspect for any suspicious executable commands or exposed secrets, such as malicious commands or application keys.

| Configuration Type | Content |
|--- | --- |
| Environment Variables | PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin |
| Environment Variables | HOME=/config |

## 1.3 Vulnerability Overview

A total of 81 vulnerabilities were scanned, including 7 critical vulnerabilities, accounting for 8.64% of the total; and 32 high-risk vulnerabilities, accounting for 39.51% of the total.

|  | Extremely dangerous | High-risk | Moderate risk | Low risk | Unknown | Total |
|--- | --- | --- | --- | --- | --- | --- |
| System Layer Component Vulnerabilities：ghcr.io/sandipb/imapfilter@sha256:701cc48f63b8334003377d36bcc7630bd418161222c3004b5dbc81bbe6bf612a (alpine 3.16.0) | 7 | 32 | 36 | 6 | 0 | 81 |
| Total number of vulnerabilities | 7 | 32 | 36 | 6 | 0 | 81 |

Among these, 81 vulnerabilities are fixable, accounting for 100.00% of the total.

| Vulnerabilities that can be fixed | Number of vulnerabilities |
|--- | --- |
| CVE-2023-46218 : curl: information disclosure by exploiting a mixed case flaw | 2 |
| CVE-2023-0286 : openssl: X.400 address type confusion in X.509 GeneralName | 2 |
| CVE-2022-43552 : curl: Use-after-free triggered by an HTTP proxy deny response | 2 |
| CVE-2023-46219 : curl: excessively long file name may lead to unknown HSTS status | 2 |
| CVE-2023-0465 : openssl: Invalid certificate policies in leaf certificates are silently ignored | 2 |
| CVE-2025-26519 : musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write ... | 2 |
| CVE-2023-28322 : curl: more POST-after-PUT confusion | 2 |
| CVE-2023-27536 : curl: GSS delegation too eager connection re-use | 2 |
| CVE-2023-27534 : curl: SFTP path ~ resolving discrepancy | 2 |
| CVE-2022-4450 : openssl: double free after calling PEM_read_bio_ex | 2 |
| CVE-2023-2650 : openssl: Possible DoS translating ASN.1 object identifiers | 2 |
| CVE-2023-3817 : OpenSSL: Excessive time spent checking DH q parameter value | 2 |
| CVE-2023-5678 : openssl: Generating excessively long X9.42 DH keys or checking excessively long X9.42 DH keys or parameters may be very slow | 2 |
| CVE-2023-38039 : curl: out of heap memory issue due to missing limit on header quantity | 2 |
| CVE-2023-42366 : busybox: A heap-buffer-overflow | 2 |
| CVE-2022-30065 : busybox: A use-after-free in Busybox's awk applet leads to denial of service | 2 |
| CVE-2022-35252 : curl: Incorrect handling of control code characters in cookies | 2 |
| CVE-2023-38546 : curl: cookie injection with none file | 2 |
| CVE-2023-0215 : openssl: use-after-free following BIO_new_NDEF | 2 |
| CVE-2023-27535 : curl: FTP too eager connection reuse | 2 |
| CVE-2023-23916 : curl: HTTP multi-header compression denial of service | 2 |
| CVE-2022-42916 : curl: HSTS bypass via IDN | 2 |
| CVE-2023-28321 : curl: IDN wildcard match may lead to Improper Cerificate Validation | 2 |
| CVE-2023-23914 : curl: HSTS ignored on multiple requests | 2 |
| CVE-2023-38545 : curl: heap based buffer overflow in the SOCKS5 proxy handshake | 2 |
| CVE-2023-27533 : curl: TELNET option IAC injection | 2 |
| CVE-2023-23915 : curl: HSTS amnesia with --parallel | 2 |
| CVE-2023-0464 : openssl: Denial of service by excessive resource usage in verifying X509 policy constraints | 2 |
| CVE-2023-3446 : openssl: Excessive time spent checking DH keys and parameters | 2 |
| CVE-2022-42915 : curl: HTTP proxy double-free | 2 |
| CVE-2022-43551 : curl: HSTS bypass via IDN | 2 |
| CVE-2023-28319 : curl: use after free in SSH sha256 fingerprint check | 2 |
| CVE-2023-27538 : curl: SSH connection too eager reuse still | 2 |
| CVE-2022-4304 : openssl: timing attack in RSA Decryption implementation | 2 |
| CVE-2022-32221 : curl: POST following PUT confusion | 2 |
| CVE-2023-27537 : curl: HSTS double-free | 2 |
| CVE-2023-28320 : curl: siglongjmp race condition may lead to crash | 2 |
| CVE-2023-29491 : ncurses: Local users can trigger security-relevant memory corruption via malformed data | 2 |
| CVE-2022-41409 : pcre2: negative repeat value in a pcre2test subject line leads to inifinite loop | 1 |
| CVE-2022-37434 : zlib: heap-based buffer over-read and overflow in inflate() in inflate.c via a large gzip header extra field | 1 |
| CVE-2023-47038 : perl: Write past buffer end via illegal user-defined Unicode property | 1 |
| CVE-2023-44487 : HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack) | 1 |
| CVE-2023-35945 : envoy: HTTP/2 memory leak in nghttp2 codec | 1 |

The software packages containing vulnerabilities are listed below:。

| Software Package Name | Number of vulnerabilities included |
|--- | --- |
| curl | 24 |
| libcurl | 24 |
| libssl1.1 | 10 |
| libcrypto1.1 | 10 |
| busybox | 2 |
| nghttp2-libs | 2 |
| ssl_client | 2 |
| ncurses-terminfo-base | 1 |
| perl | 1 |
| musl | 1 |
| pcre2 | 1 |
| zlib | 1 |
| musl-utils | 1 |
| ncurses-libs | 1 |

The full list of vulnerabilities is shown below. For detailed vulnerability information, please refer to the scan results in Part Two.

| Vulnerability Name | Number of vulnerabilities |
|--- | --- |
| CVE-2022-35252 : curl: Incorrect handling of control code characters in cookies | 2 |
| CVE-2023-27538 : curl: SSH connection too eager reuse still | 2 |
| CVE-2023-23916 : curl: HTTP multi-header compression denial of service | 2 |
| CVE-2022-4304 : openssl: timing attack in RSA Decryption implementation | 2 |
| CVE-2023-46218 : curl: information disclosure by exploiting a mixed case flaw | 2 |
| CVE-2023-46219 : curl: excessively long file name may lead to unknown HSTS status | 2 |
| CVE-2023-28322 : curl: more POST-after-PUT confusion | 2 |
| CVE-2023-38546 : curl: cookie injection with none file | 2 |
| CVE-2023-29491 : ncurses: Local users can trigger security-relevant memory corruption via malformed data | 2 |
| CVE-2022-30065 : busybox: A use-after-free in Busybox's awk applet leads to denial of service | 2 |
| CVE-2022-43551 : curl: HSTS bypass via IDN | 2 |
| CVE-2023-27536 : curl: GSS delegation too eager connection re-use | 2 |
| CVE-2023-0215 : openssl: use-after-free following BIO_new_NDEF | 2 |
| CVE-2023-0286 : openssl: X.400 address type confusion in X.509 GeneralName | 2 |
| CVE-2023-38545 : curl: heap based buffer overflow in the SOCKS5 proxy handshake | 2 |
| CVE-2023-3817 : OpenSSL: Excessive time spent checking DH q parameter value | 2 |
| CVE-2023-28321 : curl: IDN wildcard match may lead to Improper Cerificate Validation | 2 |
| CVE-2023-5678 : openssl: Generating excessively long X9.42 DH keys or checking excessively long X9.42 DH keys or parameters may be very slow | 2 |
| CVE-2025-26519 : musl libc 0.9.13 through 1.2.5 before 1.2.6 has an out-of-bounds write ... | 2 |
| CVE-2023-27534 : curl: SFTP path ~ resolving discrepancy | 2 |
| CVE-2023-28319 : curl: use after free in SSH sha256 fingerprint check | 2 |
| CVE-2023-27533 : curl: TELNET option IAC injection | 2 |
| CVE-2022-42915 : curl: HTTP proxy double-free | 2 |
| CVE-2023-0465 : openssl: Invalid certificate policies in leaf certificates are silently ignored | 2 |
| CVE-2023-23914 : curl: HSTS ignored on multiple requests | 2 |
| CVE-2023-38039 : curl: out of heap memory issue due to missing limit on header quantity | 2 |
| CVE-2023-27537 : curl: HSTS double-free | 2 |
| CVE-2023-28320 : curl: siglongjmp race condition may lead to crash | 2 |
| CVE-2023-42366 : busybox: A heap-buffer-overflow | 2 |
| CVE-2023-27535 : curl: FTP too eager connection reuse | 2 |
| CVE-2023-3446 : openssl: Excessive time spent checking DH keys and parameters | 2 |
| CVE-2022-32221 : curl: POST following PUT confusion | 2 |
| CVE-2022-42916 : curl: HSTS bypass via IDN | 2 |
| CVE-2023-23915 : curl: HSTS amnesia with --parallel | 2 |
| CVE-2022-43552 : curl: Use-after-free triggered by an HTTP proxy deny response | 2 |
| CVE-2022-4450 : openssl: double free after calling PEM_read_bio_ex | 2 |
| CVE-2023-0464 : openssl: Denial of service by excessive resource usage in verifying X509 policy constraints | 2 |
| CVE-2023-2650 : openssl: Possible DoS translating ASN.1 object identifiers | 2 |
| CVE-2023-44487 : HTTP/2: Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack) | 1 |
| CVE-2022-41409 : pcre2: negative repeat value in a pcre2test subject line leads to inifinite loop | 1 |
| CVE-2023-35945 : envoy: HTTP/2 memory leak in nghttp2 codec | 1 |
| CVE-2022-37434 : zlib: heap-based buffer over-read and overflow in inflate() in inflate.c via a large gzip header extra field | 1 |
| CVE-2023-47038 : perl: Write past buffer end via illegal user-defined Unicode property | 1 |
